### PR TITLE
Make `withTreeSitterPlugins` overridable.

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -112,7 +112,7 @@ let
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ../repos/emacs/emacs-unstable.json { });
 
-  emacsGitTreeSitter = mkGitEmacs "emacs-git-tree-sitter" ../repos/emacs/emacs-feature_tree-sitter.json {
+  emacsGitTreeSitter = super.lib.makeOverridable (mkGitEmacs "emacs-git-tree-sitter" ../repos/emacs/emacs-feature_tree-sitter.json) {
     withTreeSitter = true;
     withTreeSitterPlugins = (plugins: with plugins; [
       tree-sitter-python


### PR DESCRIPTION
Allow the tree-sitter plugins to be overridable until the attributes are upstreamed.